### PR TITLE
Add a webview full screen support for android by implementing onShowC…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -26,7 +26,6 @@ import android.text.TextUtils;
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.ConsoleMessage;
 import android.webkit.GeolocationPermissions;
-import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.JavascriptInterface;
@@ -332,8 +331,8 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   @Override
   protected WebView createViewInstance(ThemedReactContext reactContext) {
-    ReactWebView webView = new ReactWebView(reactContext);
-    webView.setWebChromeClient(new WebChromeClient() {
+    final ReactWebView webView = new ReactWebView(reactContext);
+    webView.setWebChromeClient(new VideoWebChromeClient(reactContext.getCurrentActivity(), webView) {
       @Override
       public boolean onConsoleMessage(ConsoleMessage message) {
         if (ReactBuildConfig.DEBUG) {
@@ -405,7 +404,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   public void setAllowUniversalAccessFromFileURLs(WebView view, boolean allow) {
     view.getSettings().setAllowUniversalAccessFromFileURLs(allow);
   }
-  
+
   @ReactProp(name = "saveFormDataDisabled")
   public void setSaveFormDataDisabled(WebView view, boolean disable) {
     view.getSettings().setSaveFormData(!disable);
@@ -499,7 +498,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         view.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
       } else if ("compatibility".equals(mixedContentMode)) {
         view.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
-      } 
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
+import android.content.pm.ActivityInfo;
 
 import static android.view.ViewGroup.LayoutParams;
 
@@ -47,6 +48,7 @@ public class VideoWebChromeClient extends WebChromeClient {
     view.setBackgroundColor(Color.BLACK);
 
     getRootView().addView(view, FULLSCREEN_LAYOUT_PARAMS);
+    mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
   }
 
   @Override
@@ -63,6 +65,7 @@ public class VideoWebChromeClient extends WebChromeClient {
     getRootView().removeView(mVideoView);
     mVideoView = null;
     mCustomViewCallback.onCustomViewHidden();
+    mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
   }
 
   private ViewGroup getRootView() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
@@ -1,0 +1,71 @@
+package com.facebook.react.views.webview;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import android.widget.FrameLayout;
+
+import static android.view.ViewGroup.LayoutParams;
+
+/**
+ * Provides support for full-screen video on Android
+ */
+public class VideoWebChromeClient extends WebChromeClient {
+
+  private final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
+    LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER);
+
+  private WebChromeClient.CustomViewCallback mCustomViewCallback;
+
+  private Activity mActivity;
+  private View mWebView;
+  private View mVideoView;
+
+  public VideoWebChromeClient(Activity activity, WebView webView) {
+    mWebView = webView;
+    mActivity = activity;
+  }
+
+  @Override
+  public void onShowCustomView(View view, CustomViewCallback callback) {
+    if (mVideoView != null) {
+      return;
+    }
+
+    // Store the view and it's callback for later, so we can dispose of them correctly
+    mVideoView = view;
+    mCustomViewCallback = callback;
+
+    mVideoView.setVisibility(View.VISIBLE);
+
+    mWebView.setVisibility(View.GONE);
+
+    view.setBackgroundColor(Color.BLACK);
+
+    getRootView().addView(view, FULLSCREEN_LAYOUT_PARAMS);
+  }
+
+  @Override
+  public void onHideCustomView() {
+    if (mVideoView == null) {
+      return;
+    }
+
+    mWebView.setVisibility(View.VISIBLE);
+
+    mVideoView.setVisibility(View.GONE);
+
+    // Remove the custom view from its container.
+    getRootView().removeView(mVideoView);
+    mVideoView = null;
+    mCustomViewCallback.onCustomViewHidden();
+  }
+
+  private ViewGroup getRootView() {
+    return ((ViewGroup) mActivity.findViewById(android.R.id.content));
+  }
+}


### PR DESCRIPTION
From android document:
"In order to support full screen — for video or other HTML content — you need to set a **WebChromeClient** and implement both **onShowCustomView**(View, WebChromeClient.CustomViewCallback) and **onHideCustomView**(). If the implementation of either of these two methods is missing then the web contents will not be allowed to enter full screen."